### PR TITLE
Fix tsconfig ("npm run build" should not create build/ subfolders)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "resin-lint --typescript src tests",
     "prettify": "prettier --config ./node_modules/resin-lint/config/.prettierrc --write \"{src,tests}/**/*.ts\" gulpfile.js",
     "test": "gulp test",
+    "prebuild": "rimraf build/",
     "build": "npm run lint && gulp build"
   },
   "files": [
@@ -45,6 +46,7 @@
     "mocha": "^6.2.0",
     "prettier": "^1.18.2",
     "resin-lint": "^3.1.0",
+    "rimraf": "^3.0.0",
     "ts-node": "^8.4.1",
     "typescript": "^3.6.3"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "target": "es2017"
   },
   "include": [
-    "src/",
-    "tests/"
+    "src/"
   ]
 }


### PR DESCRIPTION
After publishing the v1.0.0 of the `docker-qemu-transpose` package to the npm registry, an attempt to use it in `balena-cli` results in:
```
$ DEBUG=1 ./bin/balena build ...
...
Error: Cannot find module 'docker-qemu-transpose'
```

My investigation points to the `build/` folder incorrectly containing `src` and `tests` subfolders:
```
build/src/index.js
build/src/index.js.map
build/tests/...
```
It should instead look like:
```
build/index.js
build/index.js.map
```

Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>